### PR TITLE
Hotfix/exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@firemanjs/fireman",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@firemanjs/fireman",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firemanjs/fireman",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Fireman API and CLI",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firemanjs/fireman",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Fireman API and CLI",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './firestore/firestore';
+export * from './firestore/collection';
+export * from './firestore/query-result';
+export * from './firestore/document';
 export * from './auth';


### PR DESCRIPTION
Add necessary Firestore types like `Document` or `QueryResult` to index exports